### PR TITLE
Refactor leader and registry lookups to use Result type

### DIFF
--- a/examples/two_nodes_app/examples_node_a.gleam
+++ b/examples/two_nodes_app/examples_node_a.gleam
@@ -1,9 +1,9 @@
 import distribute/cluster
 import distribute/cluster/membership
+import distribute/monitor
 import gleam/io
 import gleam/option
 import gleam/string
-import distribute/monitor
 
 pub fn start() -> Nil {
   // Start this node in distributed mode (short name)
@@ -22,8 +22,8 @@ pub fn start() -> Nil {
   io.println("Alive nodes: " <> string.inspect(alive))
   let leader = membership.current_leader()
   case leader {
-    option.Some(l) -> io.println("Current leader: " <> l)
-    option.None -> io.println("No leader elected")
+    Ok(l) -> io.println("Current leader: " <> l)
+    Error(Nil) -> io.println("No leader elected")
   }
 
   // Keep the function alive; the integration script will keep the BEAM VM running

--- a/src/distribute/cluster/health.gleam
+++ b/src/distribute/cluster/health.gleam
@@ -4,7 +4,6 @@
 /// and the overall cluster, based on membership status and connectivity.
 import distribute/cluster/membership
 import gleam/list
-import gleam/option
 
 /// Health status of the cluster.
 pub type ClusterHealth {
@@ -98,6 +97,6 @@ pub fn has_quorum(expected_nodes: Int) -> Bool {
 }
 
 /// Get the current leader if available.
-pub fn current_leader() -> option.Option(String) {
+pub fn current_leader() -> Result(String, Nil) {
   membership.current_leader()
 }

--- a/src/distribute/cluster/membership.gleam
+++ b/src/distribute/cluster/membership.gleam
@@ -83,13 +83,11 @@ pub fn suspect() -> List(String) {
   suspect_ffi()
 }
 
-import gleam/option
-
-pub fn current_leader() -> option.Option(String) {
+pub fn current_leader() -> Result(String, Nil) {
   let s = current_leader_ffi()
   case s {
-    "" -> option.None
-    _ -> option.Some(s)
+    "" -> Error(Nil)
+    _ -> Ok(s)
   }
 }
 

--- a/src/distribute/election/raft_lite.gleam
+++ b/src/distribute/election/raft_lite.gleam
@@ -8,7 +8,6 @@
 ///    based on the lexicographically largest node among the alive members.
 import distribute/cluster/membership
 import gleam/list
-import gleam/option
 import gleam/string
 
 @external(erlang, "raft_ffi", "start")
@@ -74,11 +73,11 @@ pub fn send_heartbeat(leader: String) -> Nil {
 
 /// Get the current leader from the Raft service.
 /// Returns the leader node name, or empty string if no leader.
-pub fn get_raft_leader() -> option.Option(String) {
+pub fn get_raft_leader() -> Result(String, Nil) {
   let leader = get_leader_ffi()
   case leader {
-    "" -> option.None
-    _ -> option.Some(leader)
+    "" -> Error(Nil)
+    _ -> Ok(leader)
   }
 }
 
@@ -109,10 +108,10 @@ pub fn elect() -> ElectionResult {
   }
 }
 
-/// Convenience: return the current leader as `Option(String)`.
-pub fn current_leader() -> option.Option(String) {
+/// Convenience: return the current leader as `Result(String, Nil)`.
+pub fn current_leader() -> Result(String, Nil) {
   case elect() {
-    Leader(n) -> option.Some(n)
-    NoLeader -> option.None
+    Leader(n) -> Ok(n)
+    NoLeader -> Error(Nil)
   }
 }

--- a/src/distribute/registry.gleam
+++ b/src/distribute/registry.gleam
@@ -6,9 +6,8 @@
 /// When a process is registered globally, it can be looked up by name from any
 /// node in the cluster. If a network partition occurs, the registry will
 /// eventually resolve conflicts when the partition heals.
-import gleam/option.{type Option, None, Some}
-import gleam/string
 import distribute/log
+import gleam/string
 
 pub type RegisterError {
   /// Name is already registered by another process.
@@ -144,12 +143,12 @@ pub fn unregister(name: String) -> Result(Nil, RegisterError) {
 }
 
 /// Look up a globally registered process by name.
-/// Returns Some(pid) if found, None otherwise.
-pub fn whereis(name: String) -> Option(Pid) {
+/// Returns Ok(pid) if found, Error(Nil) otherwise.
+pub fn whereis(name: String) -> Result(Pid, Nil) {
   log.debug("Resolving global name", [#("name", name)])
   let res = whereis_ffi(name)
   case is_pid(res) {
-    True -> Some(dynamic_to_pid(res))
-    False -> None
+    True -> Ok(dynamic_to_pid(res))
+    False -> Error(Nil)
   }
 }

--- a/test/distribute_test.gleam
+++ b/test/distribute_test.gleam
@@ -1,11 +1,5 @@
 import distribute/cluster
 import distribute/connection_pool
-import gleam/dynamic
-import gleam/list
-import gleam/option
-import gleam/string
-import gleeunit
-import gleeunit/should
 import distribute/groups
 import distribute/log
 import distribute/messaging
@@ -13,6 +7,12 @@ import distribute/monitor
 import distribute/node_builder
 import distribute/registry
 import distribute/remote_call
+import gleam/dynamic
+import gleam/list
+import gleam/option
+import gleam/string
+import gleeunit
+import gleeunit/should
 
 pub fn main() -> Nil {
   // Disable logging during tests to keep output clean
@@ -83,7 +83,7 @@ pub fn cluster_start_node_cookie_too_long_validation_test() {
 
 pub fn registry_whereis_nonexistent_returns_none_test() {
   let result = registry.whereis("nonexistent_process_name_12345")
-  should.equal(result, option.None)
+  should.equal(result, Error(Nil))
 }
 
 pub fn registry_register_error_types_exist_test() {
@@ -1345,8 +1345,8 @@ pub fn raft_lite_current_leader_test() {
   // In single node test, should return None
   let result = raft_lite.current_leader()
   case result {
-    option.None -> should.be_true(True)
-    option.Some(_) -> should.be_true(True)
+    Error(Nil) -> should.be_true(True)
+    Ok(_) -> should.be_true(True)
   }
 }
 
@@ -1369,8 +1369,8 @@ pub fn raft_lite_am_i_leader_test() {
 pub fn raft_lite_get_raft_leader_test() {
   let result = raft_lite.get_raft_leader()
   case result {
-    option.None -> should.be_true(True)
-    option.Some(_) -> should.be_true(True)
+    Error(Nil) -> should.be_true(True)
+    Ok(_) -> should.be_true(True)
   }
 }
 
@@ -1414,8 +1414,8 @@ pub fn membership_current_leader_test() {
   membership.start_service(100)
   let leader = membership.current_leader()
   case leader {
-    option.None -> should.be_true(True)
-    option.Some(_) -> should.be_true(True)
+    Error(Nil) -> should.be_true(True)
+    Ok(_) -> should.be_true(True)
   }
   membership.stop_service()
 }
@@ -1526,8 +1526,8 @@ pub fn health_current_leader_test() {
   membership.start_service(100)
   let leader = health.current_leader()
   case leader {
-    option.None -> should.be_true(True)
-    option.Some(_) -> should.be_true(True)
+    Error(Nil) -> should.be_true(True)
+    Ok(_) -> should.be_true(True)
   }
   membership.stop_service()
 }


### PR DESCRIPTION
Replaces uses of option.Option with Result for leader election and registry lookup functions across the codebase. Updates all relevant function signatures, implementations, and tests to use Result, improving error handling consistency and clarity.