### PR TITLE
Avoid removed list.range API in actor pool

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -4,9 +4,9 @@
 packages = [
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
-  { name = "gleam_stdlib", version = "0.68.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F7FAEBD8EF260664E86A46C8DBA23508D1D11BB3BCC6EE1B89B3BC3E5C83FF1E" },
-  { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
-  { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "telemetry", version = "1.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "2172E05A27531D3D31DD9782841065C50DD5C3C7699D95266B2EDD54C2DAFA1C" },
 ]
 
 [requirements]

--- a/src/distribute/actor.gleam
+++ b/src/distribute/actor.gleam
@@ -128,7 +128,7 @@ pub fn pool(
 ) -> Result(process.Pid, actor.StartError) {
   let name_prefix = registry.typed_name_to_string(typed_name)
   let specs =
-    list.range(1, size)
+    range(1, size)
     |> list.map(fn(i) {
       let worker_name = name_prefix <> "_" <> int.to_string(i)
       let worker_tn = registry.pool_member(typed_name, i)
@@ -162,5 +162,16 @@ pub fn pool(
   case static_supervisor.start(builder) {
     Ok(sup) -> Ok(sup.pid)
     Error(err) -> Error(err)
+  }
+}
+
+fn range(start: Int, stop: Int) -> List(Int) {
+  range_loop(start, stop, [])
+}
+
+fn range_loop(current: Int, stop: Int, acc: List(Int)) -> List(Int) {
+  case current > stop {
+    True -> list.reverse(acc)
+    False -> range_loop(current + 1, stop, [current, ..acc])
   }
 }


### PR DESCRIPTION
This fixes compatibility with newer gleam_stdlib versions.\n\n`distribute/actor.gleam` used `list.range`, but that function is not available across the package's declared `gleam_stdlib >= 0.60.0 and < 2.0.0` range. This replaces the call with a small local range helper, preserving the existing behavior without narrowing the dependency constraint.\n\nVerification:\n\n- Ran `gleam test` against this repository.\n- The existing test suite passes.