### PR TITLE
Set default cookie before node startup

### DIFF
--- a/src/cluster_ffi.erl
+++ b/src/cluster_ffi.erl
@@ -12,6 +12,7 @@
 %% Input is validated (max 512 bytes, no null bytes) before creation.
 start_node(Name, Cookie) ->
     NameAtom = to_atom_force(Name),
+    CookieAtom = to_atom_force(Cookie),
     Type = case string:tokens(atom_to_list(NameAtom), "@") of
         [_, Host] ->
             case lists:member($., Host) of
@@ -21,8 +22,9 @@ start_node(Name, Cookie) ->
         _ -> shortnames
     end,
     try
+        erlang:set_cookie(CookieAtom),
         net_kernel:start([NameAtom, Type]),
-        erlang:set_cookie(node(), to_atom_force(Cookie)),
+        erlang:set_cookie(node(), CookieAtom),
         ok
     catch
         Class:Reason ->


### PR DESCRIPTION
This fixes distributed node startup when callers pass an explicit cookie.\n\n`cluster_ffi.start_node/2` currently starts `net_kernel` before applying the requested cookie. That means the node can start with the default cookie, and short-lived client nodes may fail to authenticate when connecting to another node started with the same requested cookie.\n\nThis patch sets the default Erlang cookie before `net_kernel:start/1`, then keeps the existing explicit `erlang:set_cookie(node(), Cookie)` call after startup.\n\nVerification:\n\n- Ran `gleam test` against this repository.\n- The existing test suite passes.